### PR TITLE
Document api

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,47 @@ This should help when debugging requests.
 ### Users
 
 This resource implements the create, update, and destroy actions for a user.
-Also, this resource contains an action to associate a user with a control server.
+Also, this resource contains an action to associate a user with a control server and to get the currently logged in user.
 All paths are namespaced under `/auth/users`.
+
+#### Get the currently logged in user
+
+* Method: `GET`
+* Path: `/auth/users/logged_in`
+* Response Codes:
+  * 200 - User was found
+  * 404 - No user logged in
+
+```
+$ curl --verbose \
+       --request GET \
+       --header 'Cookie: session_key=nYiaeeea7dvsr14RL1qC%2Fg%3D%3D;' \
+       http://localhost:4567/auth/users/logged_in
+
+* Hostname was NOT found in DNS cache
+*   Trying ::1...
+* connect to ::1 port 4567 failed: Connection refused
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 4567 (#0)
+> GET /auth/users/logged_in HTTP/1.1
+> User-Agent: curl/7.37.1
+> Host: localhost:4567
+> Accept: */*
+> Cookie: session_key=nYiaeeea7dvsr14RL1qC%2Fg%3D%3D;
+>
+< HTTP/1.1 200 OK
+< Date: Mon, 16 Feb 2015 14:08:40 GMT
+< Status: 200 OK
+< Connection: close
+< Content-Type: application/json
+< Content-Length: 49
+< X-Content-Type-Options: nosniff
+<
+* Closing connection 0
+{"id":1,"name":"Jonny","email":"jonny@gmail.com"}
+```
+
+session_key=nYiaeeea7dvsr14RL1qC%2Fg%3D%3D;
 
 #### Create a new user
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ $ curl --verbose \
 * Closing connection 0
 ```
 
-## Contorl Servers
+## Control Servers
 
 This resource implements the create and destroy actions for a Control Servers.
 All paths are namespaced under `/auth/control_servers`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,373 @@
 # Cappy Auth
 
-This web app handles authentication for our capstone project.
+This web app handles authentication and user/control server coordination for our capstone project.
+It does so by providing a REST API that uses JSON to communicate with the control sevrers and frontend.
+
+## API
+
+The API implements limited CRUD functionality for Users, Sessions, and Control Servers.
+All error responses (>= `400`) return the failing error class and message to the client.
+This should help when debugging requests.
+
+### Users
+
+This resource implements the create, update, and destroy actions for a user.
+Also, this resource contains an action to associate a user with a control server.
+All paths are namespaced under `/auth/users`.
+
+#### Create a new user
+
+* Method: `POST`
+* Path: `/auth/users/`
+* Response Codes:
+  * 201 - A new user was created
+  * 400 - Invalid data JSON sent as the post body
+  * 409 - There is already a user with the given email
+
+Example:
+
+```shell
+$ curl --verbose \
+       --request POST \
+       --data @- \
+       http://localhost:4567/auth/users/ <<EOF
+{
+  "name": "Jonny",
+  "email": "jonny@gmail.com",
+  "password": "trustno1"
+}
+EOF
+
+* Hostname was NOT found in DNS cache
+*   Trying ::1...
+* connect to ::1 port 4567 failed: Connection refused
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 4567 (#0)
+> POST /auth/users/ HTTP/1.1
+> User-Agent: curl/7.37.1
+> Host: localhost:4567
+> Accept: */*
+> Content-Length: 64
+> Content-Type: application/x-www-form-urlencoded
+>
+* upload completely sent off: 64 out of 64 bytes
+< HTTP/1.1 201 Created
+< Date: Sun, 15 Feb 2015 16:26:37 GMT
+< Status: 201 Created
+< Connection: close
+< Content-Type: application/json
+< Content-Length: 49
+< X-Content-Type-Options: nosniff
+<
+* Closing connection 0
+{"id":1,"name":"Jonny","email":"jonny@gmail.com"}
+```
+
+### Update a User
+
+* Method: `PUT`
+* Path: `/auth/users/:user_id/`
+* Response Codes:
+  * 200 - User data was updated
+  * 400 - Invalid data JSON sent as the post body
+  * 403 - Please log in (see the Sessions API for information about this)
+  * 404 - No such user exists
+  * 409 - There is already a user with the given email
+
+Example:
+
+```shell
+$ curl --verbose \
+       --request PUT \
+       --header 'Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;' \
+       --data @- \
+       http://localhost:4567/auth/users/1 <<EOF
+{
+  "name": "Jon"
+}
+EOF
+
+* Hostname was NOT found in DNS cache
+*   Trying ::1...
+* connect to ::1 port 4567 failed: Connection refused
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 4567 (#0)
+> PUT /auth/users/1 HTTP/1.1
+> User-Agent: curl/7.37.1
+> Host: localhost:4567
+> Accept: */*
+> Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;
+> Content-Length: 17
+> Content-Type: application/x-www-form-urlencoded
+>
+* upload completely sent off: 17 out of 17 bytes
+< HTTP/1.1 200 OK
+< Date: Sun, 15 Feb 2015 22:29:18 GMT
+< Status: 200 OK
+< Connection: close
+< Content-Type: application/json
+< Content-Length: 4
+< X-Content-Type-Options: nosniff
+<
+* Closing connection 0
+true
+```
+
+### Destroy a User
+
+* Method: `DELETE`
+* Path: `/auth/users/:user_id/`
+* Response Codes:
+  * 204 - User was deleted
+  * 403 - Please log in (see the Sessions API for information about this)
+  * 404 - No such user exists
+
+Example:
+
+```shell
+$ curl --verbose \
+       --header 'Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;' \
+       --request DELETE \
+       http://localhost:4567/auth/users/1
+
+* Hostname was NOT found in DNS cache
+*   Trying ::1...
+* connect to ::1 port 4567 failed: Connection refused
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 4567 (#0)
+> DELETE /auth/users/1 HTTP/1.1
+> User-Agent: curl/7.37.1
+> Host: localhost:4567
+> Accept: */*
+> Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;
+>
+< HTTP/1.1 204 No Content
+< Date: Sun, 15 Feb 2015 22:30:39 GMT
+< Status: 204 No Content
+< Connection: close
+< X-Content-Type-Options: nosniff
+<
+* Closing connection 0
+```
+
+### Associate a User with a Control Server
+
+* Method: `POST`
+* Path: `/auth/users/:user_id/associate/`
+* Response Codes:
+  * 201 - Association created
+  * 403 - Please log in
+  * 404 - No control server found
+
+Example:
+
+```shell
+$ curl --verbose \
+       --request POST \
+       --header 'Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;' \
+       http://localhost:4567/auth/users/1/associate
+
+* Hostname was NOT found in DNS cache
+*   Trying ::1...
+* connect to ::1 port 4567 failed: Connection refused
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 4567 (#0)
+> POST /auth/users/1/associate HTTP/1.1
+> User-Agent: curl/7.37.1
+> Host: localhost:4567
+> Accept: */*
+> Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;
+>
+< HTTP/1.1 201 Created
+< Date: Sun, 15 Feb 2015 22:53:45 GMT
+< Status: 201 Created
+< Connection: close
+< Content-Type: application/json
+< Content-Length: 0
+< X-Content-Type-Options: nosniff
+<
+* Closing connection 0
+```
+
+## Sessions
+
+This resource implements the create and destroy actions for a session.
+All paths are namespaced under `/auth/sessions`.
+
+### Create a Session
+
+* Method: `POST`
+* Path: `/auth/sessions/`
+* Response Codes:
+  * 201 - Session was created
+  * 401 - Invalid password
+  * 404 - No user found for the given email
+
+Example:
+
+```shell
+$ curl --verbose \
+       --request POST \
+       --data @- \
+       http://localhost:4567/auth/sessions <<EOF
+{
+  "email": "jonny@gmail.com",
+  "password": "trustno1"
+}
+EOF
+
+* Hostname was NOT found in DNS cache
+*   Trying ::1...
+* connect to ::1 port 4567 failed: Connection refused
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 4567 (#0)
+> POST /auth/sessions HTTP/1.1
+> User-Agent: curl/7.37.1
+> Host: localhost:4567
+> Accept: */*
+> Content-Length: 55
+> Content-Type: application/x-www-form-urlencoded
+>
+* upload completely sent off: 55 out of 55 bytes
+< HTTP/1.1 201 Created
+< Date: Sun, 15 Feb 2015 22:16:48 GMT
+< Status: 201 Created
+< Connection: close
+< Content-Type: application/json
+< Set-Cookie: session_key=fvaAiddxIe%2F7yxxQ2DlMaQ%3D%3D; expires=Tue, 17 Mar 2015 21:16:48 -0000
+< Content-Length: 98
+< X-Content-Type-Options: nosniff
+<
+* Closing connection 0
+{"id":1,"key":"fvaAiddxIe/7yxxQ2DlMaQ==","expires_on":"2015-03-17T17:16:48.583-04:00","user_id":1}
+```
+
+### Destroy a Session
+
+* Method: `DELETE`
+* Path: `/auth/sessions/`
+* Response Codes:
+  * 204 - Session was destroyed
+  * 404 - No session found or cookie header was not set
+
+Example:
+
+```shell
+$ curl --verbose \
+       --header 'Cookie: session_key=fvaAiddxIe%2F7yxxQ2DlMaQ%3D%3D;' \
+       --request DELETE \
+       http://localhost:4567/auth/sessions
+
+* Hostname was NOT found in DNS cache
+*   Trying ::1...
+* connect to ::1 port 4567 failed: Connection refused
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 4567 (#0)
+> DELETE /auth/sessions HTTP/1.1
+> User-Agent: curl/7.37.1
+> Host: localhost:4567
+> Accept: */*
+> Cookie: session_key=fvaAiddxIe%2F7yxxQ2DlMaQ%3D%3D;
+>
+< HTTP/1.1 204 No Content
+< Date: Sun, 15 Feb 2015 22:20:36 GMT
+< Status: 204 No Content
+< Connection: close
+< Set-Cookie: session_key=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000
+< X-Content-Type-Options: nosniff
+<
+* Closing connection 0
+```
+
+## Contorl Servers
+
+This resource implements the create and destroy actions for a Control Servers.
+All paths are namespaced under `/auth/control_servers`.
+
+### Create a Control Server
+
+* Method: `POST`
+* Path: `/auth/control_servers/`
+* Response Codes:
+  * 201 - Control server updated
+  * 400 - Invalid/malformed options
+  * 409 - Control server with UUID already exists
+
+```shell
+$ curl --verbose \
+       --request POST \
+       --data @- \
+       http://localhost:4567/auth/control_servers <<EOF
+{
+  "port": 12345,
+  "uuid": "SOME-UUID"
+}
+EOF
+* Hostname was NOT found in DNS cache
+*   Trying ::1...
+* connect to ::1 port 4567 failed: Connection refused
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 4567 (#0)
+> POST /auth/control_servers HTTP/1.1
+> User-Agent: curl/7.37.1
+> Host: localhost:4567
+> Accept: */*
+> Content-Length: 39
+> Content-Type: application/x-www-form-urlencoded
+>
+* upload completely sent off: 39 out of 39 bytes
+< HTTP/1.1 201 Created
+< Date: Sun, 15 Feb 2015 22:44:14 GMT
+< Status: 201 Created
+< Connection: close
+< Content-Type: application/json
+< Content-Length: 57
+< X-Content-Type-Options: nosniff
+<
+* Closing connection 0
+{"id":1,"uuid":"SOME-UUID","ip":"127.0.0.1","port":12345}
+```
+
+### Update a Control Server
+
+* Method: `PUT`
+* Path: `/auth/control_servers/:uuid/`
+* Response Codes:
+  * 200 - Control server updated
+  * 400 - Invalid/malformed control server options
+  * 404 - No control server found
+
+```shell
+$ curl --verbose \
+       --request PUT \
+       --data @- \
+       http://localhost:4567/auth/control_servers/SOME-UUID <<EOF
+{
+  "port": 23456
+}
+EOF
+
+* Hostname was NOT found in DNS cache
+*   Trying ::1...
+* connect to ::1 port 4567 failed: Connection refused
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 4567 (#0)
+> PUT /auth/control_servers/SOME-UUID HTTP/1.1
+> User-Agent: curl/7.37.1
+> Host: localhost:4567
+> Accept: */*
+> Content-Length: 17
+> Content-Type: application/x-www-form-urlencoded
+>
+* upload completely sent off: 17 out of 17 bytes
+< HTTP/1.1 200 OK
+< Date: Sun, 15 Feb 2015 22:45:26 GMT
+< Status: 200 OK
+< Connection: close
+< Content-Type: application/json
+< Content-Length: 4
+< X-Content-Type-Options: nosniff
+<
+* Closing connection 0
+true
+```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Example:
 ```shell
 $ curl --verbose \
        --request PUT \
-       --header 'Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;' \
+       --header 'Cookie: session_key=z03ksA2ARNsCUUof378LkA%3D%3D;' \
        --data @- \
        http://localhost:4567/auth/users/1 <<EOF
 {
@@ -135,21 +135,21 @@ EOF
 > User-Agent: curl/7.37.1
 > Host: localhost:4567
 > Accept: */*
-> Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;
+> Cookie: session_key=z03ksA2ARNsCUUof378LkA%3D%3D;
 > Content-Length: 17
 > Content-Type: application/x-www-form-urlencoded
 >
 * upload completely sent off: 17 out of 17 bytes
 < HTTP/1.1 200 OK
-< Date: Sun, 15 Feb 2015 22:29:18 GMT
+< Date: Mon, 16 Feb 2015 14:22:28 GMT
 < Status: 200 OK
 < Connection: close
 < Content-Type: application/json
-< Content-Length: 4
+< Content-Length: 47
 < X-Content-Type-Options: nosniff
 <
 * Closing connection 0
-true
+{"id":1,"name":"Jon","email":"jonny@gmail.com"}
 ```
 
 ### Destroy a User
@@ -203,7 +203,7 @@ Example:
 ```shell
 $ curl --verbose \
        --request POST \
-       --header 'Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;' \
+       --header 'Cookie: session_key=z03ksA2ARNsCUUof378LkA%3D%3D;' \
        http://localhost:4567/auth/users/1/associate
 
 * Hostname was NOT found in DNS cache
@@ -215,17 +215,18 @@ $ curl --verbose \
 > User-Agent: curl/7.37.1
 > Host: localhost:4567
 > Accept: */*
-> Cookie: session_key=1WHTgv9hdYmwpl16PZ3t0A%3D%3D;
+> Cookie: session_key=z03ksA2ARNsCUUof378LkA%3D%3D;
 >
 < HTTP/1.1 201 Created
-< Date: Sun, 15 Feb 2015 22:53:45 GMT
+< Date: Mon, 16 Feb 2015 14:24:11 GMT
 < Status: 201 Created
 < Connection: close
 < Content-Type: application/json
-< Content-Length: 0
+< Content-Length: 202
 < X-Content-Type-Options: nosniff
 <
 * Closing connection 0
+{"id":1,"name":"Jon","email":"jonny@gmail.com","control_server":{"id":1,"uuid":"SOME-UUID","ip":"127.0.0.1","port":23456,"created_at":"2015-02-16T14:23:14.342Z","updated_at":"2015-02-16T14:23:23.543Z"}}
 ```
 
 ## Sessions
@@ -400,13 +401,13 @@ EOF
 >
 * upload completely sent off: 17 out of 17 bytes
 < HTTP/1.1 200 OK
-< Date: Sun, 15 Feb 2015 22:45:26 GMT
+< Date: Mon, 16 Feb 2015 14:23:23 GMT
 < Status: 200 OK
 < Connection: close
 < Content-Type: application/json
-< Content-Length: 4
+< Content-Length: 57
 < X-Content-Type-Options: nosniff
 <
 * Closing connection 0
-true
+{"id":1,"uuid":"SOME-UUID","ip":"127.0.0.1","port":23456}
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -45,8 +45,8 @@ end
 
 desc 'Run the Docker build'
 task :docker do
-  system("docker build -t backend:#{SHA} .") || fail('Unable to build backend')
-  system("docker tag -f backend:#{SHA} backend:latest") || fail('Unable to tag docker image')
+  system("docker build -t auth:#{SHA} .") || fail('Unable to build auth')
+  system("docker tag -f auth:#{SHA} auth:latest") || fail('Unable to tag docker image')
 end
 
 desc 'Run the specs and quality metrics'

--- a/app/auth/controllers/base.rb
+++ b/app/auth/controllers/base.rb
@@ -10,7 +10,7 @@ module Auth
 
       error do |err|
         case err
-        when Errors::BadModelOptions
+        when Errors::BadModelOptions, Errors::MalformedRequestError
           status 400
         when Errors::BadPassword
           status 401

--- a/app/auth/controllers/control_servers.rb
+++ b/app/auth/controllers/control_servers.rb
@@ -13,7 +13,8 @@ module Auth
 
       put '/control_servers/:uuid/?' do |uuid|
         status 200
-        update(uuid, parse_json(req_body).merge('ip' => request.ip)).to_json
+        update(uuid, parse_json(req_body).merge('ip' => request.ip))
+        read(uuid).to_json
       end
     end
   end

--- a/app/auth/controllers/users.rb
+++ b/app/auth/controllers/users.rb
@@ -21,6 +21,7 @@ module Auth
         status 200
         attrs = parse_json(req_body).except('password_hash', 'password_salt')
         update(id, attrs).to_json
+        read(id).to_json
       end
 
       delete '/users/:id/?' do |id|
@@ -34,6 +35,7 @@ module Auth
         status 201
         control_server = Services::ControlServers.for_ip(request.ip)
         associate_control_server(logged_in_user.id, control_server['uuid'])
+        read(id).to_json
       end
     end
   end

--- a/app/auth/controllers/users.rb
+++ b/app/auth/controllers/users.rb
@@ -20,7 +20,7 @@ module Auth
         ensure_user_logged_in! id
         status 200
         attrs = parse_json(req_body).except('password_hash', 'password_salt')
-        update(id, attrs).to_json
+        update(id, attrs)
         read(id).to_json
       end
 

--- a/app/auth/controllers/users.rb
+++ b/app/auth/controllers/users.rb
@@ -5,6 +5,12 @@ module Auth
     class Users < Base
       helpers { include Services::Users }
 
+      get '/users/logged_in/?' do
+        fail Errors::NoSuchModel, 'No user is logged in' if logged_in_user.nil?
+        status 200
+        logged_in_user.to_json
+      end
+
       post '/users/?' do
         status 201
         create(parse_json(req_body)).to_json

--- a/app/auth/services/control_servers.rb
+++ b/app/auth/services/control_servers.rb
@@ -9,16 +9,20 @@ module Auth
       def create(uuid, ip, port)
         if Models::ControlServer.exists?(uuid: uuid)
           fail Errors::ConflictingModelOptions, "UUID already exists #{uuid}"
-        else
-          wrap_active_record_errors do
-            Models::ControlServer.create!(uuid: uuid, ip: ip, port: port).as_json
-          end
+        end
+
+        wrap_active_record_errors do
+          Models::ControlServer.create!(uuid: uuid, ip: ip, port: port).as_json
         end
       end
 
+      def read(uuid)
+        get_control_server(uuid).as_json
+      end
+
       def update(uuid, attrs)
-        control_server = Models::ControlServer.find_by(uuid: uuid)
-        fail Errors::NoSuchModel, "No such uuid: #{uuid}" unless control_server
+        control_server = get_control_server(uuid)
+
         wrap_active_record_errors do
           control_server.update_attributes!(attrs).as_json
         end
@@ -28,6 +32,12 @@ module Auth
         control_server = Models::ControlServer.find_by(ip: ip)
         fail Errors::NoSuchModel, "No such ip: #{ip}" unless control_server
         control_server.as_json
+      end
+
+      def get_control_server(uuid)
+        Models::ControlServer.find_by(uuid: uuid).tap do |control_server|
+          fail Errors::NoSuchModel, "No such uuid: #{uuid}" unless control_server
+        end
       end
     end
   end

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 constants = Auth::Controllers.constants.map(&Auth::Controllers.method(:const_get))
 controllers = constants.select { |const| const.is_a?(Class) && (const < Sinatra::Base) }
-run Rack::Cascade.new(controllers)
+map('/auth') { run Rack::Cascade.new(controllers) }
 

--- a/spec/app/auth/controllers/users_spec.rb
+++ b/spec/app/auth/controllers/users_spec.rb
@@ -5,6 +5,34 @@ describe Auth::Controllers::Users do
 
   let(:app) { described_class.new }
 
+  describe 'GET /users/logged_in/' do
+    let(:user) { create(:user) }
+
+    context 'when no user is logged in' do
+      it 'returns a 404' do
+        get '/users/logged_in/'
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+
+    context 'when a user is logged in' do
+      let(:session) { create(:session, user: user) }
+      let(:body) { JSON.parse(last_response.body) }
+
+      before { set_cookie "session_key=#{session.key}" }
+
+      it 'returns that user' do
+        get '/users/logged_in/'
+
+        expect(last_response.status).to eq(200)
+        expect(body['id']).to eq(user.id)
+        expect(body['name']).to eq(user.name)
+        expect(body['email']).to eq(user.email)
+      end
+    end
+  end
+
   describe 'POST /users/' do
     context 'when invalid options are passed' do
       let(:options) { { invalid_option: 400 } }
@@ -190,7 +218,7 @@ describe Auth::Controllers::Users do
 
         before { env 'REMOTE_ADDR', ip }
 
-        it 'associates the user with that control server', :cur do
+        it 'associates the user with that control server' do
           post "/users/#{user.id}/associate"
 
           expect(last_response.status).to eq(201)

--- a/spec/app/auth/services/control_servers_spec.rb
+++ b/spec/app/auth/services/control_servers_spec.rb
@@ -36,6 +36,27 @@ describe Auth::Services::ControlServers do
     end
   end
 
+  describe '.read' do
+    let(:uuid) { 'SOME-UUID' }
+    let(:contol_server) { build(:control_server, uuid: uuid) }
+
+    context 'when the uuid cannot be found' do
+      it 'raises a NoSuchModel error' do
+        expect { subject.read(uuid) }
+          .to raise_error(Auth::Errors::NoSuchModel)
+      end
+    end
+
+    context 'when the uuid can be found' do
+      before { contol_server.save! }
+
+      it 'returns that control server' do
+        expect(subject.read(uuid).values_at('uuid', 'ip', 'port'))
+          .to eq([contol_server.uuid, contol_server.ip, contol_server.port])
+      end
+    end
+  end
+
   describe '.update' do
     let(:control_server) { build(:control_server, ip: '123.45.67.80') }
     let(:ip) { '123.45.67.89' }


### PR DESCRIPTION
Add a README to document the HTTP routes.

@AdamEdgett @Daniel0524 see the [Users](https://github.com/cappity-cappity-capstone/auth/blob/document-api/README.md#users) and [Sessions](https://github.com/cappity-cappity-capstone/auth/blob/document-api/README.md#sessions) portions for the endpoints available to the front end.
@djosborne @tlunter  see the [Control Servers](https://github.com/cappity-cappity-capstone/auth/blob/document-api/README.md#contorl-servers) section for the endpoints available to the backend.

Let me know if anything is wrong or doesn't make sense.