### PR TITLE
You are so insensitive

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,5 +49,16 @@ task :docker do
   system("docker tag -f auth:#{SHA} auth:latest") || fail('Unable to tag docker image')
 end
 
+namespace :one_offs do
+  desc 'Convert every email in the database to lower case'
+  task make_emails_lower_case_2015_03_05: :environment do
+    ActiveRecord::Base.transaction do
+      Auth::Models::User.where.not(email: nil).find_each do |user|
+        user.update_attributes!(email: user.email.downcase)
+      end
+    end
+  end
+end
+
 desc 'Run the specs and quality metrics'
 task default: [:spec, :quality]

--- a/app/auth/services/users.rb
+++ b/app/auth/services/users.rb
@@ -25,7 +25,7 @@ module Auth
 
       def update(id, hash)
         user = get_user(id)
-        email = hash['email'].try(:downcase)
+        email = hash.fetch('email', '').tap(&:downcase!)
 
         if (email != user.email) && exists?(email)
           fail Errors::ConflictingModelOptions, "A user with email '#{email}' already exists"


### PR DESCRIPTION
**BUG FIX** [Trello](https://trello.com/c/LpA7BwgX/32-username-email-shouldn-t-be-case-sensitive)

@Daniel0524 @tlunter 

Ignore email casing and add a one off to change all existing emails to lower case.